### PR TITLE
Changes to more closely match stock EL tomcat package; update to 7.0.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 rpm-tomcat7
 ===========
 
-An RPM spec file to install Tomcat 7.0.
+An RPM spec file to install Tomcat 7.0. Designed to be as similar to the
+stock EL6 tomcat6 package as possible.
 
 To Build:
 
@@ -15,6 +16,6 @@ To Build:
 
 `wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.logrotate -O ~/rpmbuild/SOURCES/tomcat7.logrotate`
 
-`wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.41/bin/apache-tomcat-7.0.41.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.41.tar.gz`
+`wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.53/bin/apache-tomcat-7.0.53.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.53.tar.gz`
 
 `rpmbuild -bb ~/rpmbuild/SPECS/tomcat7.spec`

--- a/tomcat7.init
+++ b/tomcat7.init
@@ -15,7 +15,7 @@ prog="tomcat7"
 
 TOMCATDEBUG=
 TOMCATSECURITY=${SECURITY:+"-security"}
-CATALINA_HOME=${CATALINA_HOME:="/opt/tomcat6"}
+CATALINA_HOME=${CATALINA_HOME:="/usr/share/$prog"}
 RUNAS_USER=${RUNAS_USER:="tomcat"}
 WAITFOR=${WAITFOR:=3}
 CATALINA_PID="/var/run/${prog}.pid"
@@ -34,7 +34,7 @@ if [ ! -d $CATALINA_HOME ]; then
   exit 1
 fi
 
-export CATALINA_HOME CATALINA_PID JAVA_HOME
+export CATALINA_HOME CATALINA_PID JAVA_HOME JAVA_OPTS
 
 cleanup() {
   rm -f ${CATALINA_PID}

--- a/tomcat7.spec
+++ b/tomcat7.spec
@@ -6,17 +6,17 @@
 # wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.init -O ~/rpmbuild/SOURCES/tomcat7.init
 # wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.sysconfig -O ~/rpmbuild/SOURCES/tomcat7.sysconfig
 # wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.logrotate -O ~/rpmbuild/SOURCES/tomcat7.logrotate
-# wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.41/bin/apache-tomcat-7.0.41.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.41.tar.gz
+# wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.53/bin/apache-tomcat-7.0.53.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.53.tar.gz
 # rpmbuild -bb ~/rpmbuild/SPECS/tomcat7.spec
 
 %define __jar_repack %{nil}
-%define tomcat_home /opt/tomcat7
+%define tomcat_home /usr/share/tomcat7
 %define tomcat_group tomcat
 %define tomcat_user tomcat
 
 Summary:    Apache Servlet/JSP Engine, RI for Servlet 2.4/JSP 2.0 API
 Name:       tomcat7
-Version:    7.0.41
+Version:    7.0.53
 BuildArch:  noarch
 Release:    1
 License:    Apache Software License
@@ -26,7 +26,7 @@ Source0:    apache-tomcat-%{version}.tar.gz
 Source1:    %{name}.init
 Source2:    %{name}.sysconfig
 Source3:    %{name}.logrotate
-Requires:   jdk
+Requires:   java, %{name}-lib = %{version}-%{release}
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description
@@ -44,6 +44,46 @@ learn more about getting involved, click here.
 This package contains the base tomcat installation that depends on Sun's JDK and not
 on JPP packages.
 
+%package lib
+Group: Development/Compilers
+Summary: Libraries needed to run the Tomcat Web container
+Requires: %{name} = %{version}-%{release}
+
+%description lib
+Libraries needed to run the Tomcat Web container
+
+%package admin-webapps
+Group: System Environment/Applications
+Summary: The host-manager and manager web applications for Apache Tomcat
+Requires: %{name} = %{version}-%{release}
+
+%description admin-webapps
+The host-manager and manager web applications for Apache Tomcat.
+
+%package docs-webapp
+Group: System Environment/Applications
+Summary: The docs web application for Apache Tomcat
+Requires: %{name} = %{version}-%{release}
+
+%description docs-webapp
+The docs web application for Apache Tomcat.
+
+%package examples-webapp
+Group: System Environment/Applications
+Summary: The examples web application for Apache Tomcat
+Requires: %{name} = %{version}-%{release}
+
+%description examples-webapp
+The examples web application for Apache Tomcat.
+
+%package root-webapp
+Group: System Environment/Applications
+Summary: The ROOT web application for Apache Tomcat
+Requires: %{name} = %{version}-%{release}
+
+%description root-webapp
+The ROOT web application for Apache Tomcat.
+
 %prep
 %setup -q -n apache-tomcat-%{version}
 
@@ -60,12 +100,51 @@ cd %{buildroot}/%{tomcat_home}/
 ln -s /var/log/%{name}/ logs
 cd -
 
+# Put temp in /var/cache and link back.
+rm -rf %{buildroot}/%{tomcat_home}/temp
+install -d -m 755 %{buildroot}/var/cache/%{name}/temp
+cd %{buildroot}/%{tomcat_home}/
+ln -s /var/cache/%{name}/temp temp
+cd -
+
+# Put work in /var/cache and link back.
+rm -rf %{buildroot}/%{tomcat_home}/work
+install -d -m 755 %{buildroot}/var/cache/%{name}/work
+cd %{buildroot}/%{tomcat_home}/
+ln -s /var/cache/%{name}/work work
+cd -
+
 # Put conf in /etc/ and link back.
-install -d -m 755 %{buildroot}/%{_sysconfdir}
-mv %{buildroot}/%{tomcat_home}/conf %{buildroot}/%{_sysconfdir}/%{name}
+install -d -m 755 %{buildroot}/%{_sysconfdir}/%{name}/Catalina/localhost
+mv %{buildroot}/%{tomcat_home}/conf/* %{buildroot}/%{_sysconfdir}/%{name}/
+rmdir %{buildroot}/%{tomcat_home}/conf
 cd %{buildroot}/%{tomcat_home}/
 ln -s %{_sysconfdir}/%{name} conf
 cd -
+
+# Put webapps in /var/lib and link back.
+install -d -m 755 %{buildroot}/var/lib/%{name}
+mv %{buildroot}/%{tomcat_home}/webapps %{buildroot}/var/lib/%{name}
+cd %{buildroot}/%{tomcat_home}/
+ln -s /var/lib/%{name}/webapps webapps
+cd -
+
+# Put lib in /usr/share/java and link back.
+install -d -m 755 %{buildroot}/usr/share/java
+mv %{buildroot}/%{tomcat_home}/lib %{buildroot}/usr/share/java/%{name}
+cd %{buildroot}/%{tomcat_home}/
+ln -s /usr/share/java/%{name} lib
+cd -
+
+# Put docs in /usr/share/doc
+install -d -m 755 %{buildroot}/usr/share/doc/%{name}-%{version}
+mv %{buildroot}/%{tomcat_home}/{RUNNING.txt,LICENSE,NOTICE,RELEASE*} %{buildroot}/usr/share/doc/%{name}-%{version}
+
+# Put executables in /usr/bin
+rm  %{buildroot}/%{tomcat_home}/bin/*bat
+install -d -m 755 %{buildroot}/usr/{bin,sbin}
+mv %{buildroot}/%{tomcat_home}/bin/digest.sh %{buildroot}/usr/bin/%{name}-digest
+mv %{buildroot}/%{tomcat_home}/bin/tool-wrapper.sh %{buildroot}/usr/bin/%{name}-tool-wrapper
 
 # Drop init script
 install -d -m 755 %{buildroot}/%{_initrddir}
@@ -88,13 +167,39 @@ getent passwd %{tomcat_user} >/dev/null || /usr/sbin/useradd --comment "Tomcat D
 
 %files
 %defattr(-,%{tomcat_user},%{tomcat_group})
-%{tomcat_home}/*
 /var/log/%{name}/
+/var/cache/%{name}
+%dir /var/lib/%{name}/webapps
 %defattr(-,root,root)
+%{tomcat_home}/*
+%attr(0755,root,root) /usr/bin/*
+%dir /var/lib/%{name}
 %{_initrddir}/%{name}
 %{_sysconfdir}/logrotate.d/%{name}
 %config(noreplace) %{_sysconfdir}/sysconfig/%{name}
-%config(noreplace) %{_sysconfdir}/%{name}/*
+%config(noreplace) %{_sysconfdir}/%{name}
+%doc /usr/share/doc/%{name}-%{version}
+
+%files lib
+%defattr(0644,root,root,0755)
+/usr/share/java/%{name}
+
+%files admin-webapps
+%defattr(0644,root,root,0755)
+/var/lib/%{name}/webapps/host-manager
+/var/lib/%{name}/webapps/manager
+
+%files docs-webapp
+%defattr(0644,root,root,0755)
+/var/lib/%{name}/webapps/docs
+
+%files examples-webapp
+%defattr(0644,root,root,0755)
+/var/lib/%{name}/webapps/examples
+
+%files root-webapp
+%defattr(0644,root,root,0755)
+/var/lib/%{name}/webapps/ROOT
 
 %post
 chkconfig --add %{name}
@@ -111,5 +216,8 @@ if [ $1 -ge 1 ]; then
 fi
 
 %changelog
+* Fri Apr 4 2014 Elliot Kendall <elliot.kendall@ucsf.edu>
+- Update to 7.0.53
+- Changes to more closely match stock EL tomcat package
 * Mon Jul 1 2013 Nathan Milford <nathan@milford.io>
 - 7.0.41

--- a/tomcat7.sysconfig
+++ b/tomcat7.sysconfig
@@ -6,13 +6,12 @@
 #
 # This is the $JAVA_HOME of JDK, not JRE. not needed if you've setup
 # the file "/etc/profile.d/java.sh" with this variable.
-#export JAVA_HOME="/usr/java"
+export JAVA_HOME="/usr/lib/jvm/java"
 
 # CATALINA_HOME
 #
-# This is the installation directory of tomcat 5.
-# Default is /opt/tomcat6.
-#CATALINA_HOME="/opt/tomcat6"
+# This is the installation directory of tomcat.
+CATALINA_HOME="/usr/share/tomcat7"
 
 # RUNAS_USER
 #


### PR DESCRIPTION
I needed a tomcat7 package for EL6 that closely matches the structure of the native tomcat6 package, so that it can be used with the tomcat Chef cookbook. So I made a few changes to your artifacts:
- Moved tomcat home to /usr/share/tomcat7
- Export JAVA_OPTS in the init script so that it will work with a EL-style sysconfig file with no exports
- Replaced jvm dependency with java
- Split off separate lib, admin-webapps, docs-webapp, examples-webapp, and root-webapp packages
- Move temp and work into /var/cache/tomcat7, with symlinks back
- Create /etc/tomcat7/Catalina/localhost directory
- Move webapps into /var/lib/tomcat7 with a symlink back
- Move the docs into /usr/share/doc
- Move libs into /usr/share/java/tomcat7 with a symlink back
- Move the digest and tool-wrapper scripts into /usr/bin
- Remove all .bat scripts from bin

I also updated to the latest, Tomcat 7.0.53.

I don't know what your needs are, but I thought I'd send you a request in case you'd like to merge.
