### PR TITLE
v7.0.41 tar.gz source no longer hosted at motorology.com but v7.0.55 is

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ To Build:
 
 `wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.logrotate -O ~/rpmbuild/SOURCES/tomcat7.logrotate`
 
-`wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.41/bin/apache-tomcat-7.0.41.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.41.tar.gz`
+`wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.55/bin/apache-tomcat-7.0.55.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.55.tar.gz`
 
 `rpmbuild -bb ~/rpmbuild/SPECS/tomcat7.spec`

--- a/tomcat7.spec
+++ b/tomcat7.spec
@@ -6,7 +6,7 @@
 # wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.init -O ~/rpmbuild/SOURCES/tomcat7.init
 # wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.sysconfig -O ~/rpmbuild/SOURCES/tomcat7.sysconfig
 # wget https://raw.github.com/nmilford/rpm-tomcat7/master/tomcat7.logrotate -O ~/rpmbuild/SOURCES/tomcat7.logrotate
-# wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.41/bin/apache-tomcat-7.0.41.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.41.tar.gz
+# wget http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.55/bin/apache-tomcat-7.0.55.tar.gz -O ~/rpmbuild/SOURCES/apache-tomcat-7.0.55.tar.gz
 # rpmbuild -bb ~/rpmbuild/SPECS/tomcat7.spec
 
 %define __jar_repack %{nil}
@@ -16,7 +16,7 @@
 
 Summary:    Apache Servlet/JSP Engine, RI for Servlet 2.4/JSP 2.0 API
 Name:       tomcat7
-Version:    7.0.41
+Version:    7.0.55
 BuildArch:  noarch
 Release:    1
 License:    Apache Software License
@@ -111,5 +111,7 @@ if [ $1 -ge 1 ]; then
 fi
 
 %changelog
+* Thu Sep 4 2014 Edward Bartholomew <edward@bartholomew>
+- 7.0.55
 * Mon Jul 1 2013 Nathan Milford <nathan@milford.io>
 - 7.0.41

--- a/tomcat7.sysconfig
+++ b/tomcat7.sysconfig
@@ -10,9 +10,9 @@
 
 # CATALINA_HOME
 #
-# This is the installation directory of tomcat 5.
-# Default is /opt/tomcat6.
-#CATALINA_HOME="/opt/tomcat6"
+# This is the installation directory of tomcat 7.
+# Default is /opt/tomcat7.
+#CATALINA_HOME="/opt/tomcat7"
 
 # RUNAS_USER
 #


### PR DESCRIPTION
http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.41bin/apache-tomcat-7.0.41.tar.gz no longer exists but 
version 7.0.55 does:
http://www.motorlogy.com/apache/tomcat/tomcat-7/v7.0.55/bin/apache-tomcat-7.0.55.tar.gz 

The only other non-comment change was to make CATALINA_HOME default to /opt/tomcat7 rather than /opt/tomcat6
